### PR TITLE
wysiwyg on source code changes does not detect it being dirty right away and thus not showing an asterisk symbol

### DIFF
--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -91,7 +91,6 @@ pimcore.bundle.tinymce.editor = Class.create({
         }
 
         const maxChars = this.maxChars;
-        let changedContent = false;
 
         function checkCharCount() {
             tinymce.activeEditor.getBody().style.border = '';
@@ -135,13 +134,6 @@ pimcore.bundle.tinymce.editor = Class.create({
                     }));
                 }.bind(this));
                 editor.on('change', function (eChange) {
-                    changedContent = true;
-                }.bind(this));
-                editor.on('blur', function (eChange) {
-                    if (!changedContent) {
-                        return;
-                    }
-                    changedContent = false;
                     document.dispatchEvent(new CustomEvent(pimcore.events.changeWysiwyg, {
                         detail: {
                             e: eChange,


### PR DESCRIPTION
resolves #5 