### PR TITLE
[Bug]: Add 'ui_mode' option to TinyMCE configuration to prevent text being covered by toolbar

### DIFF
--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -114,6 +114,7 @@ pimcore.bundle.tinymce.editor = Class.create({
             ],
             content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:14px }',
             inline: true,
+            ui_mode: 'split',
             base_url: '/bundles/pimcoretinymce/build/tinymce',
             suffix: '.min',
             convert_urls: false,


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/657

## Additional info
Based on the feedback of https://github.com/pimcore/admin-ui-classic-bundle/issues/657#issuecomment-2461823171

Credits to @hadl for suggesting the right fix
