### PR TITLE
[Bug]: Fix Editor disappears when editing html for a translation due split ui_mode

### DIFF
--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -30,8 +30,7 @@ pimcore.bundle.tinymce.editor = Class.create({
             } else {
                 this.maxChars = -1;
             }
-            e.detail.config = Object.assign({}, {ui_mode: 'combined'}, e.detail.config);
-        } else {
+        } else if (e.detail.context === 'document') {
             e.detail.config = Object.assign({}, {ui_mode: 'split'}, e.detail.config);
         }
 


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/ee-tinymce-bundle/issues/18

## Additional info
`combined` is by default when not set anyways, just strictly apply `split` mode to documents which works as intended.