### PR TITLE
Allow phpunit/phpunit patch and minor updates via caret constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "roave/security-advisories": "dev-latest",
     "phpstan/phpstan": "^1.10.5",
     "phpstan/phpstan-symfony": "^1.2.20",
-    "phpunit/phpunit": "10.2.7",
+    "phpunit/phpunit": "^10.2.7",
     "nyholm/psr7": "^1"
   },
   "autoload": {


### PR DESCRIPTION
## Summary
- Relax the `phpunit/phpunit` composer constraint from pinned `10.2.7` to `^10.2.7` to allow patch/minor updates.

## Test plan
- [ ] `composer update phpunit/phpunit` resolves without conflicts
- [ ] Test suite passes with the updated dependency