### PR TITLE
Run PHP-CS-Fixer on pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/php-cs-fixer.yaml
+++ b/.github/workflows/php-cs-fixer.yaml
@@ -1,7 +1,7 @@
 name: "PHP-CS-Fixer"
 
 on:
-    pull_request_target:
+    pull_request:
         branches:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"


### PR DESCRIPTION
Aligns the PHP-CS-Fixer trigger with the standard: run on `pull_request` rather than `pull_request_target`. Auto-fix continues to work for same-repo PRs; external PRs run with a read-only token (no write access needed for style checks). Part of the PR-trigger standardization.