### PR TITLE
Replace PR Policy with thin caller for reusable workflow

### DIFF
--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,7 +1,9 @@
 name: PR Policy
 
-# Enforces PR requirements before merge. Make the "Milestone assigned" check required
-# (repo ruleset / branch protection) so it actually blocks merging.
+# Thin caller — the policy logic lives in
+# pimcore/workflows-collection-public/.github/workflows/reusable-pr-policy.yml
+# and changes there apply automatically. Make the "PR Policy / Milestone assigned"
+# check required (repo ruleset / branch protection) so it actually blocks merging.
 
 on:
   pull_request:
@@ -12,31 +14,17 @@ on:
       - ready_for_review
       - milestoned
       - demilestoned
+      - labeled
+      - unlabeled
 
 permissions:
   contents: read
 
+concurrency:
+  group: pr-policy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
-  milestone:
-    name: Milestone assigned
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check milestone
-        env:
-          MILESTONE: ${{ github.event.pull_request.milestone.title }}
-          AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: |
-          # Automated sync PRs (repo-file-sync-action) never carry a milestone.
-          if [ "$AUTHOR" = "pimcore-deployments" ]; then
-            echo "Skipping milestone check for automated PR by $AUTHOR"
-            exit 0
-          fi
-
-          if [ -z "$MILESTONE" ]; then
-            echo "::error::A milestone must be assigned before this pull request can be merged."
-            exit 1
-          fi
-
-          echo "Milestone assigned: $MILESTONE"
+  pr-policy:
+    name: PR Policy
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-pr-policy.yml@main


### PR DESCRIPTION
Part of pimcore/DevOps-Tasks#43.

The PR Policy logic now lives in the reusable workflow
`pimcore/workflows-collection-public/.github/workflows/reusable-pr-policy.yml`
(pimcore/workflows-collection-public#164). This one-time change replaces the
previously synced self-contained workflow with a thin caller that never needs
editing; future policy changes apply automatically via `@main`.

New behavior included: PRs carrying the `Skip Milestone Check` label are exempt
from the mandatory milestone check. Note the check context changes from
`Milestone assigned` to `PR Policy / Milestone assigned` — required-check
configuration must be updated accordingly.